### PR TITLE
Implement OpenAI streaming provider

### DIFF
--- a/src/ShellMuse.Cli/Program.cs
+++ b/src/ShellMuse.Cli/Program.cs
@@ -1,11 +1,14 @@
 using System;
+using System.Net.Http;
+using System.Threading.Tasks;
 using ShellMuse.Core.Config;
+using ShellMuse.Core.Providers;
 
 namespace ShellMuse.Cli;
 
 public static class Program
 {
-    public static int Main(string[] args)
+    public static async Task<int> Main(string[] args)
     {
         if (args.Length == 0 || args[0] == "ask")
         {
@@ -17,7 +20,11 @@ public static class Program
             }
             var prompt = args[start];
             var config = ConfigLoader.Load();
-            Console.WriteLine($"ASK '{prompt}' (model {config.Model})");
+            using var http = new HttpClient();
+            var provider = new OpenAIChatProvider(http, config);
+            await foreach (var chunk in provider.StreamChatAsync(prompt))
+                Console.Write(chunk);
+            Console.WriteLine();
             return 0;
         }
         else if (args[0] == "run")

--- a/src/ShellMuse.Cli/appsettings.json
+++ b/src/ShellMuse.Cli/appsettings.json
@@ -2,5 +2,6 @@
   "Model": "gpt-4o",
   "Temperature": 0.2,
   "MaxTokens": 2048,
-  "DockerImage": "ghcr.io/shellmuse/runtime:dotnet-slim"
+  "DockerImage": "ghcr.io/shellmuse/runtime:dotnet-slim",
+  "OpenAIApiKey": ""
 }

--- a/src/ShellMuse.Core/Config/AppConfig.cs
+++ b/src/ShellMuse.Core/Config/AppConfig.cs
@@ -6,5 +6,6 @@ public record AppConfig
     public double Temperature { get; init; } = 0.2;
     public int MaxTokens { get; init; } = 2048;
     public string DockerImage { get; init; } = "ghcr.io/shellmuse/runtime:dotnet-slim";
+    public string OpenAIApiKey { get; init; } = string.Empty;
 }
 

--- a/src/ShellMuse.Core/Providers/IChatProvider.cs
+++ b/src/ShellMuse.Core/Providers/IChatProvider.cs
@@ -1,0 +1,6 @@
+namespace ShellMuse.Core.Providers;
+
+public interface IChatProvider
+{
+    IAsyncEnumerable<string> StreamChatAsync(string prompt, CancellationToken cancellationToken = default);
+}

--- a/src/ShellMuse.Core/Providers/IChatProvider.cs
+++ b/src/ShellMuse.Core/Providers/IChatProvider.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Threading;
+
 namespace ShellMuse.Core.Providers;
 
 public interface IChatProvider

--- a/src/ShellMuse.Core/Providers/OpenAIChatProvider.cs
+++ b/src/ShellMuse.Core/Providers/OpenAIChatProvider.cs
@@ -1,8 +1,10 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Threading;
 using ShellMuse.Core.Config;
 
 namespace ShellMuse.Core.Providers;
@@ -39,12 +41,12 @@ public class OpenAIChatProvider : IChatProvider
 
         while (!reader.EndOfStream && !cancellationToken.IsCancellationRequested)
         {
-            var line = await reader.ReadLineAsync();
+            var line = await reader.ReadLineAsync(cancellationToken);
             if (line == null)
                 continue;
             if (!line.StartsWith("data:"))
                 continue;
-            var data = line.Substring(5).Trim();
+            var data = line[5..].Trim();
             if (data == "[DONE]")
                 yield break;
 

--- a/src/ShellMuse.Core/Providers/OpenAIChatProvider.cs
+++ b/src/ShellMuse.Core/Providers/OpenAIChatProvider.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ShellMuse.Core.Config;
+
+namespace ShellMuse.Core.Providers;
+
+public class OpenAIChatProvider : IChatProvider
+{
+    private readonly HttpClient _client;
+    private readonly AppConfig _config;
+
+    public OpenAIChatProvider(HttpClient client, AppConfig config)
+    {
+        _client = client;
+        _config = config;
+    }
+
+    public async IAsyncEnumerable<string> StreamChatAsync(string prompt, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://api.openai.com/v1/chat/completions");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _config.OpenAIApiKey);
+        var payload = new
+        {
+            model = _config.Model,
+            messages = new[] { new { role = "user", content = prompt } },
+            temperature = _config.Temperature,
+            max_tokens = _config.MaxTokens,
+            stream = true
+        };
+        request.Content = JsonContent.Create(payload);
+
+        using var response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        using var reader = new StreamReader(stream);
+
+        while (!reader.EndOfStream && !cancellationToken.IsCancellationRequested)
+        {
+            var line = await reader.ReadLineAsync();
+            if (line == null)
+                continue;
+            if (!line.StartsWith("data:"))
+                continue;
+            var data = line.Substring(5).Trim();
+            if (data == "[DONE]")
+                yield break;
+
+            using var doc = JsonDocument.Parse(data);
+            foreach (var choice in doc.RootElement.GetProperty("choices").EnumerateArray())
+            {
+                if (choice.TryGetProperty("delta", out var delta) && delta.TryGetProperty("content", out var content))
+                {
+                    var text = content.GetString();
+                    if (!string.IsNullOrEmpty(text))
+                        yield return text!;
+                }
+            }
+        }
+    }
+}

--- a/tests/ShellMuse.Tests/OpenAIProviderTests.cs
+++ b/tests/ShellMuse.Tests/OpenAIProviderTests.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using ShellMuse.Core.Config;
+using ShellMuse.Core.Providers;
+using Xunit;
+
+namespace ShellMuse.Tests;
+
+public class OpenAIProviderTests
+{
+    [Fact]
+    public async Task StreamsCompletion()
+    {
+        var handler = new StubHandler();
+        var client = new HttpClient(handler);
+        var config = new AppConfig { OpenAIApiKey = "test" };
+        var provider = new OpenAIChatProvider(client, config);
+
+        var chunks = new List<string>();
+        await foreach (var c in provider.StreamChatAsync("hello"))
+            chunks.Add(c);
+
+        Assert.Equal(new[] { "He", "llo" }, chunks);
+    }
+
+    private class StubHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            const string data = "data: {\"choices\":[{\"delta\":{\"content\":\"He\"}}]}\n\n" +
+                                 "data: {\"choices\":[{\"delta\":{\"content\":\"llo\"}}]}\n\n" +
+                                 "data: [DONE]\n\n";
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(data)
+            };
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend `AppConfig` with `OpenAIApiKey`
- add `IChatProvider` interface and `OpenAIChatProvider`
- update CLI `ask` command to stream completions via OpenAI
- provide stub streaming test for the provider

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6846e72387c88331a83e71a8a68498ac