### PR TITLE
Improve tool failure errors

### DIFF
--- a/src/ShellMuse.Cli/Program.cs
+++ b/src/ShellMuse.Cli/Program.cs
@@ -14,13 +14,15 @@ public static class Program
 {
     public static async Task<int> Main(string[] args)
     {
-        if (args.Length == 0 || args[0] == "ask")
+        try
         {
-            var start = args.Length > 0 && args[0] == "ask" ? 1 : 0;
-            if (args.Length <= start)
+            if (args.Length == 0 || args[0] == "ask")
             {
-                Usage();
-                return 1;
+                var start = args.Length > 0 && args[0] == "ask" ? 1 : 0;
+                if (args.Length <= start)
+                {
+                    Usage();
+                    return 1;
             }
             var prompt = args[start];
             var config = ConfigLoader.Load();
@@ -30,14 +32,14 @@ public static class Program
                 Console.Write(chunk);
             Console.WriteLine();
             return 0;
-        }
-        else if (args[0] == "run")
-        {
-            if (args.Length < 2)
-            {
-                Usage();
-                return 1;
             }
+            else if (args[0] == "run")
+            {
+                if (args.Length < 2)
+                {
+                    Usage();
+                    return 1;
+                }
             var task = args[1];
             var runOpts = ParseRun(args, 2);
             var config = ConfigLoader.Load();
@@ -49,12 +51,18 @@ public static class Program
             var planner = new Planner(provider, palette, runOpts.MaxSteps);
             var rules = RulesLoader.Load(repoPath);
             var contextInfo = await GitContext.CaptureAsync();
-            await planner.RunAsync(task, rules + "\n" + contextInfo);
-            return 0;
+                await planner.RunAsync(task, rules + "\n" + contextInfo);
+                return 0;
+            }
+            else
+            {
+                Usage();
+                return 1;
+            }
         }
-        else
+        catch (InvalidOperationException ex)
         {
-            Usage();
+            Console.Error.WriteLine(ex.Message);
             return 1;
         }
     }

--- a/src/ShellMuse.Core/Planning/Planner.cs
+++ b/src/ShellMuse.Core/Planning/Planner.cs
@@ -30,8 +30,14 @@ public class Planner
         for (int step = 0; step < _maxSteps; step++)
         {
             var toolJson = await RequestToolAsync(context.ToString(), cancellationToken);
-            if (!ToolCall.TryParse(toolJson, out var call) || call == null)
-                throw new InvalidOperationException($"Invalid tool call at step {step}: {toolJson}");
+            if (!ToolCall.TryParse(toolJson, out var call, out var parseError) || call == null)
+            {
+                var snippet = toolJson.Length <= 200 ? toolJson : toolJson[..200] + "...";
+                var msg = parseError != null
+                    ? $"Invalid tool call at step {step}: {parseError}. Response: {snippet}"
+                    : $"Invalid tool call at step {step}: {snippet}";
+                throw new InvalidOperationException(msg);
+            }
 
             try
             {

--- a/src/ShellMuse.Core/Planning/ToolCall.cs
+++ b/src/ShellMuse.Core/Planning/ToolCall.cs
@@ -6,25 +6,37 @@ namespace ShellMuse.Core.Planning;
 public record ToolCall(Tool Tool, JsonElement Args)
 {
     public static bool TryParse(string json, out ToolCall? call)
+        => TryParse(json, out call, out _);
+
+    public static bool TryParse(string json, out ToolCall? call, out string? error)
     {
         call = null;
+        error = null;
         try
         {
             using var doc = JsonDocument.Parse(json);
             var root = doc.RootElement;
             if (!root.TryGetProperty("tool", out var toolProp))
+            {
+                error = "Missing 'tool' property";
                 return false;
+            }
             var name = toolProp.GetString() ?? string.Empty;
             if (!Enum.TryParse<Tool>(name, true, out var tool))
+            {
+                error = $"Unknown tool '{name}'";
                 return false;
+            }
             var args = root.TryGetProperty("args", out var a)
-                ? JsonDocument.Parse(a.GetRawText()).RootElement : default;
+                ? JsonDocument.Parse(a.GetRawText()).RootElement
+                : default;
 
             call = new ToolCall(tool, args);
             return true;
         }
-        catch (JsonException)
+        catch (JsonException je)
         {
+            error = je.Message;
             return false;
         }
     }


### PR DESCRIPTION
## Summary
- show parse errors when tool JSON is invalid
- only print a short snippet of the provider response
- catch `InvalidOperationException` in the CLI so failures don't produce a stack trace

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684710c07ad083318beee3157140ea73