### PR TITLE
Add step logging to planner

### DIFF
--- a/src/ShellMuse.Cli/Program.cs
+++ b/src/ShellMuse.Cli/Program.cs
@@ -51,7 +51,7 @@ public static class Program
                 var planner = new Planner(provider, palette, runOpts.MaxSteps);
                 var rules = RulesLoader.Load(repoPath);
                 var contextInfo = await GitContext.CaptureAsync();
-                await planner.RunAsync(task, rules + "\n" + contextInfo);
+                await planner.RunAsync(task, rules + "\n" + contextInfo, Console.WriteLine);
                 return 0;
             }
             else

--- a/src/ShellMuse.Core/Planning/Planner.cs
+++ b/src/ShellMuse.Core/Planning/Planner.cs
@@ -24,6 +24,7 @@ public class Planner
     public async Task RunAsync(
         string task,
         string contextInfo = "",
+        Action<string>? stepLogger = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -46,6 +47,11 @@ public class Planner
 
             try
             {
+                var argsSnippet = call.Args.GetRawText();
+                if (argsSnippet.Length > 60)
+                    argsSnippet = argsSnippet[..60] + "...";
+                stepLogger?.Invoke($"Step {step + 1}: {call.Tool} {argsSnippet}");
+
                 var result = await _palette.ExecuteAsync(call, cancellationToken);
                 context.Append("\n");
                 context.Append(result);


### PR DESCRIPTION
## Summary
- log each planned tool call during run
- show progress in the CLI by printing planner messages

## Testing
- `dotnet build --no-restore --nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68472c6a04508331a117b59ea0b833c7