### PR TITLE
Move tool implementations

### DIFF
--- a/src/ShellMuse.Cli/Program.cs
+++ b/src/ShellMuse.Cli/Program.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using ShellMuse.Core.Config;
 using ShellMuse.Core.Git;
 using ShellMuse.Core.Planning;
+using ShellMuse.Core.Planning.Tools;
 using ShellMuse.Core.Providers;
 using ShellMuse.Core.Rules;
 using ShellMuse.Core.Sandbox;

--- a/src/ShellMuse.Core/Planning/Tools/BranchTool.cs
+++ b/src/ShellMuse.Core/Planning/Tools/BranchTool.cs
@@ -3,14 +3,14 @@ using System.Threading;
 using System.Threading.Tasks;
 using ShellMuse.Core.Sandbox;
 
-namespace ShellMuse.Core.Planning;
+namespace ShellMuse.Core.Planning.Tools;
 
-public class CommitTool : ITool
+public class BranchTool : ITool
 {
     private readonly SandboxRunner _runner;
     private readonly string _repoPath;
 
-    public CommitTool(SandboxRunner runner, string repoPath)
+    public BranchTool(SandboxRunner runner, string repoPath)
     {
         _runner = runner;
         _repoPath = repoPath;
@@ -18,7 +18,7 @@ public class CommitTool : ITool
 
     public Task<string> RunAsync(JsonElement args, CancellationToken cancellationToken = default)
     {
-        var message = args.GetProperty("message").GetString() ?? "commit";
-        return _runner.ExecAsync(_repoPath, $"git commit -am \"{message}\"", cancellationToken);
+        var name = args.GetProperty("name").GetString() ?? "muse-branch";
+        return _runner.ExecAsync(_repoPath, $"git switch -c {name}", cancellationToken);
     }
 }

--- a/src/ShellMuse.Core/Planning/Tools/BuildTool.cs
+++ b/src/ShellMuse.Core/Planning/Tools/BuildTool.cs
@@ -2,7 +2,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using ShellMuse.Core.Sandbox;
 
-namespace ShellMuse.Core.Planning;
+namespace ShellMuse.Core.Planning.Tools;
 
 public class BuildTool : ITool
 {

--- a/src/ShellMuse.Core/Planning/Tools/CommitTool.cs
+++ b/src/ShellMuse.Core/Planning/Tools/CommitTool.cs
@@ -3,14 +3,14 @@ using System.Threading;
 using System.Threading.Tasks;
 using ShellMuse.Core.Sandbox;
 
-namespace ShellMuse.Core.Planning;
+namespace ShellMuse.Core.Planning.Tools;
 
-public class BranchTool : ITool
+public class CommitTool : ITool
 {
     private readonly SandboxRunner _runner;
     private readonly string _repoPath;
 
-    public BranchTool(SandboxRunner runner, string repoPath)
+    public CommitTool(SandboxRunner runner, string repoPath)
     {
         _runner = runner;
         _repoPath = repoPath;
@@ -18,7 +18,7 @@ public class BranchTool : ITool
 
     public Task<string> RunAsync(JsonElement args, CancellationToken cancellationToken = default)
     {
-        var name = args.GetProperty("name").GetString() ?? "muse-branch";
-        return _runner.ExecAsync(_repoPath, $"git switch -c {name}", cancellationToken);
+        var message = args.GetProperty("message").GetString() ?? "commit";
+        return _runner.ExecAsync(_repoPath, $"git commit -am \"{message}\"", cancellationToken);
     }
 }

--- a/src/ShellMuse.Core/Planning/Tools/FinishTool.cs
+++ b/src/ShellMuse.Core/Planning/Tools/FinishTool.cs
@@ -2,7 +2,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace ShellMuse.Core.Planning;
+namespace ShellMuse.Core.Planning.Tools;
 
 public class FinishTool : ITool
 {

--- a/src/ShellMuse.Core/Planning/Tools/ReadFileTool.cs
+++ b/src/ShellMuse.Core/Planning/Tools/ReadFileTool.cs
@@ -3,15 +3,13 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace ShellMuse.Core.Planning;
+namespace ShellMuse.Core.Planning.Tools;
 
-public class WriteFileTool : ITool
+public class ReadFileTool : ITool
 {
     public Task<string> RunAsync(JsonElement args, CancellationToken cancellationToken = default)
     {
         var path = args.GetProperty("path").GetString() ?? string.Empty;
-        var content = args.GetProperty("content").GetString() ?? string.Empty;
-        File.WriteAllText(path, content);
-        return Task.FromResult("written");
+        return Task.FromResult(File.Exists(path) ? File.ReadAllText(path) : "");
     }
 }

--- a/src/ShellMuse.Core/Planning/Tools/SearchTool.cs
+++ b/src/ShellMuse.Core/Planning/Tools/SearchTool.cs
@@ -2,7 +2,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace ShellMuse.Core.Planning;
+namespace ShellMuse.Core.Planning.Tools;
 
 public class SearchTool : ITool
 {

--- a/src/ShellMuse.Core/Planning/Tools/TestTool.cs
+++ b/src/ShellMuse.Core/Planning/Tools/TestTool.cs
@@ -2,7 +2,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using ShellMuse.Core.Sandbox;
 
-namespace ShellMuse.Core.Planning;
+namespace ShellMuse.Core.Planning.Tools;
 
 public class TestTool : ITool
 {

--- a/src/ShellMuse.Core/Planning/Tools/WriteFileTool.cs
+++ b/src/ShellMuse.Core/Planning/Tools/WriteFileTool.cs
@@ -3,13 +3,15 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace ShellMuse.Core.Planning;
+namespace ShellMuse.Core.Planning.Tools;
 
-public class ReadFileTool : ITool
+public class WriteFileTool : ITool
 {
     public Task<string> RunAsync(JsonElement args, CancellationToken cancellationToken = default)
     {
         var path = args.GetProperty("path").GetString() ?? string.Empty;
-        return Task.FromResult(File.Exists(path) ? File.ReadAllText(path) : "");
+        var content = args.GetProperty("content").GetString() ?? string.Empty;
+        File.WriteAllText(path, content);
+        return Task.FromResult("written");
     }
 }

--- a/tests/ShellMuse.Tests/PlannerTests.cs
+++ b/tests/ShellMuse.Tests/PlannerTests.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using ShellMuse.Core.Planning;
+using ShellMuse.Core.Planning.Tools;
 using ShellMuse.Core.Providers;
 using Xunit;
 


### PR DESCRIPTION
## Summary
- group tool classes under `Planning/Tools`
- update namespaces to `ShellMuse.Core.Planning.Tools`
- import new namespace in CLI and tests

## Testing
- `git diff --check`

------
https://chatgpt.com/codex/tasks/task_e_68472ea429c483319869cba7ab82df5a