### PR TITLE
Add RulesLoaderTests

### DIFF
--- a/tests/ShellMuse.Tests/RulesLoaderTests.cs
+++ b/tests/ShellMuse.Tests/RulesLoaderTests.cs
@@ -1,0 +1,24 @@
+using System;
+using System.IO;
+using ShellMuse.Core.Rules;
+using Xunit;
+
+namespace ShellMuse.Tests;
+
+public class RulesLoaderTests
+{
+    [Fact]
+    public void LoadsAndHandlesMissingFile()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, ".muse-rules.md");
+        File.WriteAllText(path, "test rules");
+
+        Assert.Equal("test rules", RulesLoader.Load(dir));
+
+        File.Delete(path);
+
+        Assert.Equal(string.Empty, RulesLoader.Load(dir));
+    }
+}


### PR DESCRIPTION
## Summary
- add unit test for RulesLoader

## Testing
- `dotnet test ShellMuse.sln` *(fails: .NET SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_68473243373c8331b590bd8074ef86c6