### PR TITLE
Fix planner JSON tool parsing

### DIFF
--- a/src/ShellMuse.Core/Providers/OpenAIChatProvider.cs
+++ b/src/ShellMuse.Core/Providers/OpenAIChatProvider.cs
@@ -37,7 +37,16 @@ public class OpenAIChatProvider : IChatProvider
         var payload = new
         {
             model = _config.Model,
-            messages = new[] { new { role = "user", content = prompt } },
+            messages = new[]
+            {
+                new
+                {
+                    role = "system",
+                    content =
+                        "You are a coding agent. Respond ONLY with JSON matching {\"tool\":string, \"args\":object}. Available tools: search, read_file, write_file, build, test, commit, branch, finish."
+                },
+                new { role = "user", content = prompt }
+            },
             temperature = _config.Temperature,
             max_tokens = _config.MaxTokens,
             stream = true,


### PR DESCRIPTION
## Summary
- ensure OpenAI prompts include a system message instructing the model to return JSON tool calls

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68473387b15c83319a92a50d5a35c787