### PR TITLE
Add ToolCall parsing tests

### DIFF
--- a/tests/ShellMuse.Tests/ToolCallTests.cs
+++ b/tests/ShellMuse.Tests/ToolCallTests.cs
@@ -1,0 +1,38 @@
+using System.Text.Json;
+using ShellMuse.Core.Planning;
+using Xunit;
+
+namespace ShellMuse.Tests;
+
+public class ToolCallTests
+{
+    [Fact]
+    public void MissingToolPropertyFails()
+    {
+        var json = "{\"args\":{}}";
+        var ok = ToolCall.TryParse(json, out var call, out var error);
+        Assert.False(ok);
+        Assert.Null(call);
+        Assert.Equal("Missing 'tool' property", error);
+    }
+
+    [Fact]
+    public void UnknownToolReturnsFalse()
+    {
+        var json = "{\"tool\":\"bogus\"}";
+        var ok = ToolCall.TryParse(json, out var call, out var error);
+        Assert.False(ok);
+        Assert.Null(call);
+        Assert.Equal("Unknown tool 'bogus'", error);
+    }
+
+    [Fact]
+    public void MalformedJsonSurfacesError()
+    {
+        var json = "{\"tool\":\"search\""; // missing closing brace
+        var ok = ToolCall.TryParse(json, out var call, out var error);
+        Assert.False(ok);
+        Assert.Null(call);
+        Assert.False(string.IsNullOrEmpty(error));
+    }
+}


### PR DESCRIPTION
## Summary
- test ToolCall.TryParse error cases: missing tool property, unknown tool, malformed JSON

## Testing
- `dotnet test tests/ShellMuse.Tests/ShellMuse.Tests.csproj` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68474812a1a88331921e3dc9c27d7698