### PR TITLE
Add directory listing tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ shellmuse run <task> [--max-cost N --max-steps N] [-v]
 ```
 
 The `run` command executes a simple planner loop with built-in tools
-(`search`, `read_file`, `write_file`, `build`, `test`, `commit`, `branch`, `finish`).
+(`search`, `read_file`, `write_file`, `list_dir`, `build`, `test`, `commit`, `branch`, `finish`).
 
 Configuration defaults come from `appsettings.json`. Secrets can live in Visual
 Studio user secrets or environment variables prefixed with `SHELLMUSE_`.

--- a/SPEC.md
+++ b/SPEC.md
@@ -34,7 +34,7 @@ The MVP targets Windows 10/11 with PowerShell as the primary shell, implemented 
 | F-6 | Git branch workflow – Always work on a Git branch, mount repo to container with RW access | Agent creates/switches to branch before making changes |
 | F-7 | Docker sandbox execution (see §6) | Host FS Git repo modified only through container |
 | F-8 | Planner–executor loop (≤ 10 iterations) | Demo task finishes within step limit |
-| F-9 | Built-in tool palette: search, read_file, write_file, build, test, commit | Invalid tool aborts with error; commits allowed on branch |
+| F-9 | Built-in tool palette: search, read_file, write_file, list_dir, build, test, commit | Invalid tool aborts with error; commits allowed on branch |
 | F-10 | Cost & iteration guardrails (--max-cost, --max-steps) | Exceeding guard exits with code 2 |
 | F-11 | Windows/PowerShell compatibility – All paths, temp dirs work on Windows with PowerShell | CI job on Linux passes build/test acceptance |
 
@@ -97,7 +97,7 @@ docker_image  = "ghcr.io/shellmuse/runtime:dotnet-slim"
 {
   "type": "object",
   "properties": {
-    "tool": { "enum": [ "search","read_file","write_file","build","test","commit","branch","finish" ] },
+    "tool": { "enum": [ "search","read_file","write_file","list_dir","build","test","commit","branch","finish" ] },
     "args": { "type": "object" }
   },
   "required": ["tool"]

--- a/src/ShellMuse.Cli/Program.cs
+++ b/src/ShellMuse.Cli/Program.cs
@@ -111,6 +111,7 @@ public static class Program
                 (Tool.Search, new SearchTool()),
                 (Tool.ReadFile, new ReadFileTool()),
                 (Tool.WriteFile, new WriteFileTool()),
+                (Tool.ListDir, new ListDirTool()),
                 (Tool.Build, new BuildTool(runner, repoPath)),
                 (Tool.Test, new TestTool(runner, repoPath)),
                 (Tool.Commit, new CommitTool(runner, repoPath)),

--- a/src/ShellMuse.Core/Planning/Tool.cs
+++ b/src/ShellMuse.Core/Planning/Tool.cs
@@ -5,6 +5,7 @@ public enum Tool
     Search,
     ReadFile,
     WriteFile,
+    ListDir,
     Build,
     Test,
     Commit,

--- a/src/ShellMuse.Core/Planning/Tools/ListDirTool.cs
+++ b/src/ShellMuse.Core/Planning/Tools/ListDirTool.cs
@@ -1,0 +1,22 @@
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ShellMuse.Core.Planning.Tools;
+
+public class ListDirTool : ITool
+{
+    public Task<string> RunAsync(JsonElement args, CancellationToken cancellationToken = default)
+    {
+        var path = args.GetProperty("path").GetString() ?? ".";
+        if (!Directory.Exists(path))
+            return Task.FromResult(string.Empty);
+        var entries = Directory
+            .EnumerateFileSystemEntries(path)
+            .Select(Path.GetFileName)
+            .ToArray();
+        return Task.FromResult(string.Join('\n', entries));
+    }
+}

--- a/tests/ShellMuse.Tests/FileToolsTests.cs
+++ b/tests/ShellMuse.Tests/FileToolsTests.cs
@@ -32,4 +32,20 @@ public class FileToolsTests
         var result = await read.RunAsync(readArgs);
         Assert.Equal(string.Empty, result);
     }
+
+    [Fact]
+    public async Task ListDirReturnsEntries()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "a.txt"), "a");
+        Directory.CreateDirectory(Path.Combine(dir, "sub"));
+        var list = new ListDirTool();
+        var args = JsonDocument.Parse(JsonSerializer.Serialize(new { path = dir })).RootElement;
+        var result = await list.RunAsync(args);
+        var lines = result.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Contains("a.txt", lines);
+        Assert.Contains("sub", lines);
+        Directory.Delete(dir, true);
+    }
 }


### PR DESCRIPTION
## Summary
- implement `ListDirTool` to list files and folders in a directory
- expose new tool from CLI palette
- document `list_dir` in README and SPEC
- update tooling schema and feature table
- test directory listing behavior

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68474847e4608331b4e2b80f1aae22db