### PR TITLE
Load AGENTS.md into planner rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ shellmuse run <task> [--max-cost N --max-steps N] [-v]
 The `run` command executes a simple planner loop with built-in tools
 (`search`, `read_file`, `write_file`, `list_dir`, `build`, `test`, `commit`, `branch`, `finish`).
 
+If the repository contains `.muse-rules.md` or `AGENTS.md`, their contents are
+added to the prompt so the model follows your project-specific guidelines.
+
 Configuration defaults come from `appsettings.json`. Secrets can live in Visual
 Studio user secrets or environment variables prefixed with `SHELLMUSE_`.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -37,6 +37,7 @@ The MVP targets Windows 10/11 with PowerShell as the primary shell, implemented 
 | F-9 | Built-in tool palette: search, read_file, write_file, list_dir, build, test, commit | Invalid tool aborts with error; commits allowed on branch |
 | F-10 | Cost & iteration guardrails (--max-cost, --max-steps) | Exceeding guard exits with code 2 |
 | F-11 | Windows/PowerShell compatibility – All paths, temp dirs work on Windows with PowerShell | CI job on Linux passes build/test acceptance |
+| F-12 | Repository `AGENTS.md` auto-injected | Model responses follow repo instructions. |
 
 ## 4. Security Requirements
 
@@ -144,4 +145,4 @@ docker_image  = "ghcr.io/shellmuse/runtime:dotnet-slim"
 | Check if we're using that kernel library |
 | Use local OLlama llm for some stuff? |
 | Nuget tool to find latest package versions? |
-| Add something like AGENTS.md as part of prompt? |
+| Include AGENTS.md instructions in prompt |

--- a/src/ShellMuse.Core/Rules/RulesLoader.cs
+++ b/src/ShellMuse.Core/Rules/RulesLoader.cs
@@ -6,7 +6,13 @@ public static class RulesLoader
 {
     public static string Load(string repoPath)
     {
-        var path = Path.Combine(repoPath, ".muse-rules.md");
-        return File.Exists(path) ? File.ReadAllText(path) : string.Empty;
+        var sb = new System.Text.StringBuilder();
+        var rulesPath = Path.Combine(repoPath, ".muse-rules.md");
+        if (File.Exists(rulesPath))
+            sb.AppendLine(File.ReadAllText(rulesPath));
+        var agentsPath = Path.Combine(repoPath, "AGENTS.md");
+        if (File.Exists(agentsPath))
+            sb.AppendLine(File.ReadAllText(agentsPath));
+        return sb.ToString();
     }
 }

--- a/tests/ShellMuse.Tests/RulesLoaderTests.cs
+++ b/tests/ShellMuse.Tests/RulesLoaderTests.cs
@@ -12,12 +12,15 @@ public class RulesLoaderTests
     {
         var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(dir);
-        var path = Path.Combine(dir, ".muse-rules.md");
-        File.WriteAllText(path, "test rules");
+        var rules = Path.Combine(dir, ".muse-rules.md");
+        var agents = Path.Combine(dir, "AGENTS.md");
+        File.WriteAllText(rules, "rules");
+        File.WriteAllText(agents, "agents");
 
-        Assert.Equal("test rules", RulesLoader.Load(dir));
+        Assert.Equal("rules\nagents\n", RulesLoader.Load(dir));
 
-        File.Delete(path);
+        File.Delete(rules);
+        File.Delete(agents);
 
         Assert.Equal(string.Empty, RulesLoader.Load(dir));
     }


### PR DESCRIPTION
## Summary
- include `AGENTS.md` content when loading repository rules
- document `AGENTS.md` usage
- update spec to describe new feature
- adjust unit tests for RulesLoader

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68474a0f4f88833183edefe61ae2fdc1