### PR TITLE
Add OutdatedPackages tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ shellmuse run <task> [--max-cost N --max-steps N] [-v]
 ```
 
 The `run` command executes a simple planner loop with built-in tools
-(`search`, `read_file`, `write_file`, `list_dir`, `build`, `test`, `commit`, `branch`, `finish`).
+(`search`, `read_file`, `write_file`, `list_dir`, `build`, `test`, `commit`, `branch`, `outdated_packages`, `finish`).
 
 Configuration defaults come from `appsettings.json`. Secrets can live in Visual
 Studio user secrets or environment variables prefixed with `SHELLMUSE_`.

--- a/SPEC.md
+++ b/SPEC.md
@@ -34,7 +34,7 @@ The MVP targets Windows 10/11 with PowerShell as the primary shell, implemented 
 | F-6 | Git branch workflow – Always work on a Git branch, mount repo to container with RW access | Agent creates/switches to branch before making changes |
 | F-7 | Docker sandbox execution (see §6) | Host FS Git repo modified only through container |
 | F-8 | Planner–executor loop (≤ 10 iterations) | Demo task finishes within step limit |
-| F-9 | Built-in tool palette: search, read_file, write_file, list_dir, build, test, commit | Invalid tool aborts with error; commits allowed on branch |
+| F-9 | Built-in tool palette: search, read_file, write_file, list_dir, build, test, commit, outdated_packages | Invalid tool aborts with error; commits allowed on branch |
 | F-10 | Cost & iteration guardrails (--max-cost, --max-steps) | Exceeding guard exits with code 2 |
 | F-11 | Windows/PowerShell compatibility – All paths, temp dirs work on Windows with PowerShell | CI job on Linux passes build/test acceptance |
 
@@ -97,7 +97,7 @@ docker_image  = "ghcr.io/shellmuse/runtime:dotnet-slim"
 {
   "type": "object",
   "properties": {
-    "tool": { "enum": [ "search","read_file","write_file","list_dir","build","test","commit","branch","finish" ] },
+    "tool": { "enum": [ "search","read_file","write_file","list_dir","build","test","commit","branch","outdated_packages","finish" ] },
     "args": { "type": "object" }
   },
   "required": ["tool"]

--- a/src/ShellMuse.Cli/Program.cs
+++ b/src/ShellMuse.Cli/Program.cs
@@ -116,6 +116,7 @@ public static class Program
                 (Tool.Test, new TestTool(runner, repoPath)),
                 (Tool.Commit, new CommitTool(runner, repoPath)),
                 (Tool.Branch, new BranchTool(runner, repoPath)),
+                (Tool.OutdatedPackages, new OutdatedPackagesTool(runner, repoPath)),
                 (Tool.Finish, new FinishTool()),
             }
         );

--- a/src/ShellMuse.Core/Planning/Tool.cs
+++ b/src/ShellMuse.Core/Planning/Tool.cs
@@ -10,5 +10,6 @@ public enum Tool
     Test,
     Commit,
     Branch,
+    OutdatedPackages,
     Finish,
 }

--- a/src/ShellMuse.Core/Planning/Tools/OutdatedPackagesTool.cs
+++ b/src/ShellMuse.Core/Planning/Tools/OutdatedPackagesTool.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using ShellMuse.Core.Sandbox;
+
+namespace ShellMuse.Core.Planning.Tools;
+
+public class OutdatedPackagesTool : ITool
+{
+    private readonly SandboxRunner _runner;
+    private readonly string _repoPath;
+
+    public OutdatedPackagesTool(SandboxRunner runner, string repoPath)
+    {
+        _runner = runner;
+        _repoPath = repoPath;
+    }
+
+    public Task<string> RunAsync(System.Text.Json.JsonElement args, CancellationToken cancellationToken = default)
+    {
+        return _runner.ExecAsync(_repoPath, "dotnet list package --outdated", cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary
- add new `OutdatedPackagesTool` for checking outdated NuGet packages
- expose tool through CLI default palette
- document tool in README and SPEC

## Testing
- `dotnet test ShellMuse.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68474a28f1808331a207abb9eb67bd71