### PR TITLE
Enable local Ollama provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ Each project targets **.NET 9.0** and will be expanded in future milestones.
 ## Quick start
 
 1. Install the [.NET 9 SDK preview](https://dotnet.microsoft.com/download/dotnet/9.0).
-2. Export your OpenAI API key:
+2. By default ShellMuse talks to a local [Ollama](https://ollama.ai) instance on `localhost:11434`.
+   Simple requests are handled locally, while complex planning or coding prompts go to OpenAI.
+   Set `SHELLMUSE_USELOCALLLM=false` to disable Ollama entirely.
+   Export your OpenAI API key:
 
    ```powershell
    $env:SHELLMUSE_OPENAIAPIKEY = "sk-..."

--- a/src/ShellMuse.Cli/Program.cs
+++ b/src/ShellMuse.Cli/Program.cs
@@ -28,7 +28,12 @@ public static class Program
                 var prompt = args[start];
                 var config = ConfigLoader.Load();
                 using var http = new HttpClient();
-                var provider = new OpenAIChatProvider(http, config);
+                var provider = config.UseLocalLlm
+                    ? new HybridChatProvider(
+                        new OpenAIChatProvider(http, config),
+                        new OllamaChatProvider(http, config)
+                    )
+                    : new OpenAIChatProvider(http, config);
                 await foreach (var chunk in provider.StreamChatAsync(prompt))
                     Console.Write(chunk);
                 Console.WriteLine();
@@ -45,7 +50,12 @@ public static class Program
                 var runOpts = ParseRun(args, 2);
                 var config = ConfigLoader.Load();
                 using var http = new HttpClient();
-                var provider = new OpenAIChatProvider(http, config);
+                var provider = config.UseLocalLlm
+                    ? new HybridChatProvider(
+                        new OpenAIChatProvider(http, config),
+                        new OllamaChatProvider(http, config)
+                    )
+                    : new OpenAIChatProvider(http, config);
                 var repoPath = Environment.CurrentDirectory;
                 var runner = new SandboxRunner(config.DockerImage);
                 var palette = DefaultPalette(runner, repoPath);

--- a/src/ShellMuse.Core/Config/AppConfig.cs
+++ b/src/ShellMuse.Core/Config/AppConfig.cs
@@ -7,4 +7,5 @@ public record AppConfig
     public int MaxTokens { get; init; } = 2048;
     public string DockerImage { get; init; } = "ghcr.io/shellmuse/runtime:dotnet-slim";
     public string OpenAIApiKey { get; init; } = string.Empty;
+    public bool UseLocalLlm { get; init; } = true;
 }

--- a/src/ShellMuse.Core/Providers/HybridChatProvider.cs
+++ b/src/ShellMuse.Core/Providers/HybridChatProvider.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace ShellMuse.Core.Providers;
+
+public class HybridChatProvider : IChatProvider
+{
+    private readonly IChatProvider _openAi;
+    private readonly IChatProvider _ollama;
+
+    public HybridChatProvider(IChatProvider openAi, IChatProvider ollama)
+    {
+        _openAi = openAi;
+        _ollama = ollama;
+    }
+
+    public async IAsyncEnumerable<string> StreamChatAsync(
+        string prompt,
+        [System.Runtime.CompilerServices.EnumeratorCancellation]
+            CancellationToken cancellationToken = default
+    )
+    {
+        var provider = ChooseProvider(prompt);
+        var name = ReferenceEquals(provider, _ollama) ? "local Ollama" : "OpenAI";
+        Console.WriteLine($"Using {name} provider");
+        await foreach (var chunk in provider.StreamChatAsync(prompt, cancellationToken))
+            yield return chunk;
+    }
+
+    private IChatProvider ChooseProvider(string prompt)
+    {
+        var text = prompt.ToLowerInvariant();
+        if (text.Contains("plan") || text.Contains("design") || text.Contains("code") || text.Contains("implement"))
+            return _openAi;
+        return _ollama;
+    }
+}

--- a/src/ShellMuse.Core/Providers/OllamaChatProvider.cs
+++ b/src/ShellMuse.Core/Providers/OllamaChatProvider.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading;
+using ShellMuse.Core.Config;
+
+namespace ShellMuse.Core.Providers;
+
+public class OllamaChatProvider : IChatProvider
+{
+    private readonly HttpClient _client;
+    private readonly AppConfig _config;
+
+    public OllamaChatProvider(HttpClient client, AppConfig config)
+    {
+        _client = client;
+        _config = config;
+    }
+
+    public async IAsyncEnumerable<string> StreamChatAsync(
+        string prompt,
+        [System.Runtime.CompilerServices.EnumeratorCancellation]
+            CancellationToken cancellationToken = default
+    )
+    {
+        using var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            "http://localhost:11434/api/chat"
+        );
+        var payload = new
+        {
+            model = _config.Model,
+            messages = new[]
+            {
+                new
+                {
+                    role = "system",
+                    content =
+                        "You are a coding agent. Respond ONLY with JSON matching {\\\"tool\\\":string, \\\"args\\\":object}. Available tools: search, read_file, write_file, build, test, commit, branch, finish."
+                },
+                new { role = "user", content = prompt }
+            },
+            stream = true,
+        };
+        request.Content = JsonContent.Create(payload);
+
+        using var response = await _client.SendAsync(
+            request,
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken
+        );
+        response.EnsureSuccessStatusCode();
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        using var reader = new StreamReader(stream);
+
+        while (!reader.EndOfStream && !cancellationToken.IsCancellationRequested)
+        {
+            var line = await reader.ReadLineAsync(cancellationToken);
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            using var doc = JsonDocument.Parse(line);
+            if (
+                doc.RootElement.TryGetProperty("message", out var message)
+                && message.TryGetProperty("content", out var content)
+            )
+            {
+                var text = content.GetString();
+                if (!string.IsNullOrEmpty(text))
+                    yield return text!;
+            }
+
+            if (
+                doc.RootElement.TryGetProperty("done", out var doneProp)
+                && doneProp.GetBoolean()
+            )
+            {
+                yield break;
+            }
+        }
+    }
+}

--- a/tests/ShellMuse.Tests/HybridProviderTests.cs
+++ b/tests/ShellMuse.Tests/HybridProviderTests.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ShellMuse.Core.Providers;
+using Xunit;
+
+namespace ShellMuse.Tests;
+
+public class HybridProviderTests
+{
+    [Fact]
+    public async Task UsesOpenAIForComplexPrompt()
+    {
+        var openai = new StubProvider("openai");
+        var ollama = new StubProvider("ollama");
+        var provider = new HybridChatProvider(openai, ollama);
+
+        await foreach (var _ in provider.StreamChatAsync("plan the app"))
+        {
+        }
+
+        Assert.Single(openai.Prompts);
+        Assert.Empty(ollama.Prompts);
+    }
+
+    [Fact]
+    public async Task UsesOllamaForSimplePrompt()
+    {
+        var openai = new StubProvider("openai");
+        var ollama = new StubProvider("ollama");
+        var provider = new HybridChatProvider(openai, ollama);
+
+        await foreach (var _ in provider.StreamChatAsync("search foo"))
+        {
+        }
+
+        Assert.Empty(openai.Prompts);
+        Assert.Single(ollama.Prompts);
+    }
+
+    private class StubProvider : IChatProvider
+    {
+        public readonly List<string> Prompts = new();
+
+        public StubProvider(string name) {}
+
+        public async IAsyncEnumerable<string> StreamChatAsync(
+            string prompt,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default
+        )
+        {
+            Prompts.Add(prompt);
+            await Task.CompletedTask;
+            yield break;
+        }
+    }
+}

--- a/tests/ShellMuse.Tests/OllamaProviderTests.cs
+++ b/tests/ShellMuse.Tests/OllamaProviderTests.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using ShellMuse.Core.Config;
+using ShellMuse.Core.Providers;
+using Xunit;
+
+namespace ShellMuse.Tests;
+
+public class OllamaProviderTests
+{
+    [Fact]
+    public async Task StreamsCompletion()
+    {
+        var handler = new StubHandler();
+        var client = new HttpClient(handler);
+        var config = new AppConfig();
+        var provider = new OllamaChatProvider(client, config);
+
+        var chunks = new List<string>();
+        await foreach (var c in provider.StreamChatAsync("hello"))
+            chunks.Add(c);
+
+        Assert.Equal(new[] { "He", "llo" }, chunks);
+    }
+
+    private class StubHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            const string data =
+                "{\"message\":{\"content\":\"He\"},\"done\":false}\n" +
+                "{\"message\":{\"content\":\"llo\"},\"done\":true}\n";
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(data),
+            };
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `HybridChatProvider` that chooses between Ollama and OpenAI
- select provider automatically in CLI based on prompt
- document heuristic behaviour in README
- unit tests for the new provider

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68474a742f18833192e9be3cd7b10925