### PR TITLE
Fix default Docker runtime image

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Each project targets **.NET 9.0** and will be expanded in future milestones.
    dotnet run --project src/ShellMuse.Cli -- ask "2+2"
    ```
 
-5. Run a task inside the sandbox:
+5. Run a task inside the sandbox (Docker required, pulls `mcr.microsoft.com/dotnet/nightly/sdk:9.0` by default):
 
    ```bash
    dotnet run --project src/ShellMuse.Cli -- run "build the project"

--- a/SPEC.md
+++ b/SPEC.md
@@ -72,7 +72,7 @@ The MVP targets Windows 10/11 with PowerShell as the primary shell, implemented 
                     (commits allowed)
 ```
 
-**Base image**: `ghcr.io/shellmuse/runtime:dotnet-slim` (SDK, git, ripgrep)
+**Base image**: `mcr.microsoft.com/dotnet/nightly/sdk:9.0` (SDK, git, ripgrep)
 
 ## 7. Interfaces
 
@@ -89,7 +89,7 @@ shellmuse run  <task> [--max-cost 1.0 --max-steps 8] [--model gpt-4o] [-v]
 model         = "gpt-4o"
 temperature   = 0.2
 max_tokens    = 2048
-docker_image  = "ghcr.io/shellmuse/runtime:dotnet-slim"
+docker_image  = "mcr.microsoft.com/dotnet/nightly/sdk:9.0"
 ```
 
 ### 7.3 Tool JSON Schema (sent to model)

--- a/runtimes/Dockerfile
+++ b/runtimes/Dockerfile
@@ -1,3 +1,7 @@
-FROM ghcr.io/shellmuse/runtime:dotnet-slim
+FROM mcr.microsoft.com/dotnet/nightly/sdk:9.0
+
+RUN apt-get update && \
+    apt-get install -y git ripgrep && \
+    rm -rf /var/lib/apt/lists/*
 
 # Runtime container for ShellMuse agent tools

--- a/src/ShellMuse.Cli/appsettings.json
+++ b/src/ShellMuse.Cli/appsettings.json
@@ -2,6 +2,6 @@
   "Model": "gpt-4o",
   "Temperature": 0.2,
   "MaxTokens": 2048,
-  "DockerImage": "ghcr.io/shellmuse/runtime:dotnet-slim",
+  "DockerImage": "mcr.microsoft.com/dotnet/nightly/sdk:9.0",
   "OpenAIApiKey": ""
 }

--- a/src/ShellMuse.Core/Config/AppConfig.cs
+++ b/src/ShellMuse.Core/Config/AppConfig.cs
@@ -5,6 +5,6 @@ public record AppConfig
     public string Model { get; init; } = "gpt-4o";
     public double Temperature { get; init; } = 0.2;
     public int MaxTokens { get; init; } = 2048;
-    public string DockerImage { get; init; } = "ghcr.io/shellmuse/runtime:dotnet-slim";
+    public string DockerImage { get; init; } = "mcr.microsoft.com/dotnet/nightly/sdk:9.0";
     public string OpenAIApiKey { get; init; } = string.Empty;
 }


### PR DESCRIPTION
## Summary
- switch to the public `mcr.microsoft.com/dotnet/nightly/sdk:9.0` container
- update config defaults and docs
- note the runtime container dependency in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68474d6a74b48331a6928edefaf05087