### PR TITLE
Improve tool execution logging and timeouts

### DIFF
--- a/src/ShellMuse.Core/Planning/ITool.cs
+++ b/src/ShellMuse.Core/Planning/ITool.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/ShellMuse.Core/Planning/ITool.cs
+++ b/src/ShellMuse.Core/Planning/ITool.cs
@@ -6,5 +6,9 @@ namespace ShellMuse.Core.Planning;
 
 public interface ITool
 {
-    Task<string> RunAsync(JsonElement args, CancellationToken cancellationToken = default);
+    Task<string> RunAsync(
+        JsonElement args,
+        CancellationToken cancellationToken = default,
+        Action<string>? outputLogger = null
+    );
 }

--- a/src/ShellMuse.Core/Planning/Planner.cs
+++ b/src/ShellMuse.Core/Planning/Planner.cs
@@ -52,7 +52,7 @@ public class Planner
                     argsSnippet = argsSnippet[..60] + "...";
                 stepLogger?.Invoke($"Step {step + 1}: {call.Tool} {argsSnippet}");
 
-                var result = await _palette.ExecuteAsync(call, cancellationToken);
+                var result = await _palette.ExecuteAsync(call, cancellationToken, stepLogger);
                 context.Append("\n");
                 context.Append(result);
                 if (call.Tool == Tool.Finish)

--- a/src/ShellMuse.Core/Planning/ProcessUtil.cs
+++ b/src/ShellMuse.Core/Planning/ProcessUtil.cs
@@ -10,7 +10,8 @@ internal static class ProcessUtil
     public static async Task<string> RunAsync(
         string fileName,
         string arguments,
-        CancellationToken ct = default
+        CancellationToken ct = default,
+        Action<string>? outputLogger = null
     )
     {
         var psi = new ProcessStartInfo(fileName, arguments)
@@ -23,12 +24,18 @@ internal static class ProcessUtil
         proc.OutputDataReceived += (_, e) =>
         {
             if (e.Data != null)
+            {
                 sb.AppendLine(e.Data);
+                outputLogger?.Invoke(e.Data);
+            }
         };
         proc.ErrorDataReceived += (_, e) =>
         {
             if (e.Data != null)
+            {
                 sb.AppendLine(e.Data);
+                outputLogger?.Invoke(e.Data);
+            }
         };
         proc.BeginOutputReadLine();
         proc.BeginErrorReadLine();

--- a/src/ShellMuse.Core/Planning/ToolPalette.cs
+++ b/src/ShellMuse.Core/Planning/ToolPalette.cs
@@ -17,11 +17,12 @@ public class ToolPalette
 
     public async Task<string> ExecuteAsync(
         ToolCall call,
-        CancellationToken cancellationToken = default
+        CancellationToken cancellationToken = default,
+        Action<string>? outputLogger = null
     )
     {
         if (!_tools.TryGetValue(call.Tool, out var tool))
             throw new InvalidOperationException($"Unknown tool {call.Tool}");
-        return await tool.RunAsync(call.Args, cancellationToken);
+        return await tool.RunAsync(call.Args, cancellationToken, outputLogger);
     }
 }

--- a/src/ShellMuse.Core/Planning/Tools/BranchTool.cs
+++ b/src/ShellMuse.Core/Planning/Tools/BranchTool.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,9 +17,20 @@ public class BranchTool : ITool
         _repoPath = repoPath;
     }
 
-    public Task<string> RunAsync(JsonElement args, CancellationToken cancellationToken = default)
+    public Task<string> RunAsync(
+        JsonElement args,
+        CancellationToken cancellationToken = default,
+        Action<string>? outputLogger = null
+    )
     {
         var name = args.GetProperty("name").GetString() ?? "muse-branch";
-        return _runner.ExecAsync(_repoPath, $"git switch -c {name}", cancellationToken);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(TimeSpan.FromSeconds(30));
+        return _runner.ExecAsync(
+            _repoPath,
+            $"git switch -c {name}",
+            cts.Token,
+            outputLogger
+        );
     }
 }

--- a/src/ShellMuse.Core/Planning/Tools/BuildTool.cs
+++ b/src/ShellMuse.Core/Planning/Tools/BuildTool.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using ShellMuse.Core.Sandbox;
@@ -17,9 +18,17 @@ public class BuildTool : ITool
 
     public Task<string> RunAsync(
         System.Text.Json.JsonElement args,
-        CancellationToken cancellationToken = default
+        CancellationToken cancellationToken = default,
+        Action<string>? outputLogger = null
     )
     {
-        return _runner.ExecAsync(_repoPath, "dotnet build --nologo", cancellationToken);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(TimeSpan.FromMinutes(5));
+        return _runner.ExecAsync(
+            _repoPath,
+            "dotnet build --nologo",
+            cts.Token,
+            outputLogger
+        );
     }
 }

--- a/src/ShellMuse.Core/Planning/Tools/CommitTool.cs
+++ b/src/ShellMuse.Core/Planning/Tools/CommitTool.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,9 +17,20 @@ public class CommitTool : ITool
         _repoPath = repoPath;
     }
 
-    public Task<string> RunAsync(JsonElement args, CancellationToken cancellationToken = default)
+    public Task<string> RunAsync(
+        JsonElement args,
+        CancellationToken cancellationToken = default,
+        Action<string>? outputLogger = null
+    )
     {
         var message = args.GetProperty("message").GetString() ?? "commit";
-        return _runner.ExecAsync(_repoPath, $"git commit -am \"{message}\"", cancellationToken);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(TimeSpan.FromSeconds(30));
+        return _runner.ExecAsync(
+            _repoPath,
+            $"git commit -am \"{message}\"",
+            cts.Token,
+            outputLogger
+        );
     }
 }

--- a/src/ShellMuse.Core/Planning/Tools/FinishTool.cs
+++ b/src/ShellMuse.Core/Planning/Tools/FinishTool.cs
@@ -6,8 +6,13 @@ namespace ShellMuse.Core.Planning.Tools;
 
 public class FinishTool : ITool
 {
-    public Task<string> RunAsync(JsonElement args, CancellationToken cancellationToken = default)
+    public Task<string> RunAsync(
+        JsonElement args,
+        CancellationToken cancellationToken = default,
+        Action<string>? outputLogger = null
+    )
     {
+        outputLogger?.Invoke("finished");
         return Task.FromResult("done");
     }
 }

--- a/src/ShellMuse.Core/Planning/Tools/ListDirTool.cs
+++ b/src/ShellMuse.Core/Planning/Tools/ListDirTool.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -8,12 +9,20 @@ namespace ShellMuse.Core.Planning.Tools;
 
 public class ListDirTool : ITool
 {
-    public Task<string> RunAsync(JsonElement args, CancellationToken cancellationToken = default)
+    public Task<string> RunAsync(
+        JsonElement args,
+        CancellationToken cancellationToken = default,
+        Action<string>? outputLogger = null
+    )
     {
         var path = args.GetProperty("path").GetString() ?? ".";
         if (!Directory.Exists(path))
             return Task.FromResult(string.Empty);
-        var entries = Directory.EnumerateFileSystemEntries(path).Select(Path.GetFileName).ToArray();
+        var entries = Directory
+            .EnumerateFileSystemEntries(path)
+            .Select(Path.GetFileName)
+            .ToArray();
+        outputLogger?.Invoke($"listed {path}");
         return Task.FromResult(string.Join('\n', entries));
     }
 }

--- a/src/ShellMuse.Core/Planning/Tools/OutdatedPackagesTool.cs
+++ b/src/ShellMuse.Core/Planning/Tools/OutdatedPackagesTool.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using ShellMuse.Core.Sandbox;
@@ -17,9 +18,17 @@ public class OutdatedPackagesTool : ITool
 
     public Task<string> RunAsync(
         System.Text.Json.JsonElement args,
-        CancellationToken cancellationToken = default
+        CancellationToken cancellationToken = default,
+        Action<string>? outputLogger = null
     )
     {
-        return _runner.ExecAsync(_repoPath, "dotnet list package --outdated", cancellationToken);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(TimeSpan.FromMinutes(2));
+        return _runner.ExecAsync(
+            _repoPath,
+            "dotnet list package --outdated",
+            cts.Token,
+            outputLogger
+        );
     }
 }

--- a/src/ShellMuse.Core/Planning/Tools/ReadFileTool.cs
+++ b/src/ShellMuse.Core/Planning/Tools/ReadFileTool.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Text.Json;
 using System.Threading;
@@ -7,9 +8,15 @@ namespace ShellMuse.Core.Planning.Tools;
 
 public class ReadFileTool : ITool
 {
-    public Task<string> RunAsync(JsonElement args, CancellationToken cancellationToken = default)
+    public Task<string> RunAsync(
+        JsonElement args,
+        CancellationToken cancellationToken = default,
+        Action<string>? outputLogger = null
+    )
     {
         var path = args.GetProperty("path").GetString() ?? string.Empty;
-        return Task.FromResult(File.Exists(path) ? File.ReadAllText(path) : "");
+        var result = File.Exists(path) ? File.ReadAllText(path) : string.Empty;
+        outputLogger?.Invoke($"read {path}");
+        return Task.FromResult(result);
     }
 }

--- a/src/ShellMuse.Core/Planning/Tools/SearchTool.cs
+++ b/src/ShellMuse.Core/Planning/Tools/SearchTool.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -6,10 +7,14 @@ namespace ShellMuse.Core.Planning.Tools;
 
 public class SearchTool : ITool
 {
-    public Task<string> RunAsync(JsonElement args, CancellationToken cancellationToken = default)
+    public Task<string> RunAsync(
+        JsonElement args,
+        CancellationToken cancellationToken = default,
+        Action<string>? outputLogger = null
+    )
     {
         var query = args.GetProperty("query").GetString() ?? string.Empty;
         var path = args.TryGetProperty("path", out var p) ? p.GetString() ?? "." : ".";
-        return ProcessUtil.RunAsync("rg", $"{query} {path}", cancellationToken);
+        return ProcessUtil.RunAsync("rg", $"{query} {path}", cancellationToken, outputLogger);
     }
 }

--- a/src/ShellMuse.Core/Planning/Tools/TestTool.cs
+++ b/src/ShellMuse.Core/Planning/Tools/TestTool.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using ShellMuse.Core.Sandbox;
@@ -17,9 +18,17 @@ public class TestTool : ITool
 
     public Task<string> RunAsync(
         System.Text.Json.JsonElement args,
-        CancellationToken cancellationToken = default
+        CancellationToken cancellationToken = default,
+        Action<string>? outputLogger = null
     )
     {
-        return _runner.ExecAsync(_repoPath, "dotnet test --no-build --nologo", cancellationToken);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(TimeSpan.FromMinutes(5));
+        return _runner.ExecAsync(
+            _repoPath,
+            "dotnet test --no-build --nologo",
+            cts.Token,
+            outputLogger
+        );
     }
 }

--- a/src/ShellMuse.Core/Planning/Tools/WriteFileTool.cs
+++ b/src/ShellMuse.Core/Planning/Tools/WriteFileTool.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Text.Json;
 using System.Threading;
@@ -7,11 +8,16 @@ namespace ShellMuse.Core.Planning.Tools;
 
 public class WriteFileTool : ITool
 {
-    public Task<string> RunAsync(JsonElement args, CancellationToken cancellationToken = default)
+    public Task<string> RunAsync(
+        JsonElement args,
+        CancellationToken cancellationToken = default,
+        Action<string>? outputLogger = null
+    )
     {
         var path = args.GetProperty("path").GetString() ?? string.Empty;
         var content = args.GetProperty("content").GetString() ?? string.Empty;
         File.WriteAllText(path, content);
+        outputLogger?.Invoke($"wrote {path}");
         return Task.FromResult("written");
     }
 }

--- a/src/ShellMuse.Core/Sandbox/SandboxRunner.cs
+++ b/src/ShellMuse.Core/Sandbox/SandboxRunner.cs
@@ -9,10 +9,16 @@ public class SandboxRunner
 
     public SandboxRunner(string image) => _image = image;
 
-    public Task<string> ExecAsync(string repoPath, string command, CancellationToken ct = default)
+    public Task<string> ExecAsync(
+        string repoPath,
+        string command,
+        CancellationToken ct = default,
+        Action<string>? outputLogger = null
+    )
     {
         var args =
             $"run --rm --network none --read-only --cap-drop ALL --pids-limit 200 --tmpfs /tmp -v \"{repoPath}\":/workspace -w /workspace {_image} /bin/sh -c \"{command}\"";
-        return Planning.ProcessUtil.RunAsync("docker", args, ct);
+        outputLogger?.Invoke($"> docker {args}");
+        return Planning.ProcessUtil.RunAsync("docker", args, ct, outputLogger);
     }
 }

--- a/tests/ShellMuse.Tests/PlannerTests.cs
+++ b/tests/ShellMuse.Tests/PlannerTests.cs
@@ -54,7 +54,8 @@ public class PlannerTests
 
         public Task<string> RunAsync(
             JsonElement args,
-            CancellationToken cancellationToken = default
+            CancellationToken cancellationToken = default,
+            Action<string>? outputLogger = null
         )
         {
             Count++;


### PR DESCRIPTION
## Summary
- log sandbox commands and stream tool output
- add per-tool timeouts
- pass logger through planner

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847507931c083318be4cddecc2f42f7