### PR TITLE
Handle missing ripgrep gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,25 +24,26 @@ Each project targets **.NET 9.0** and will be expanded in future milestones.
 ## Quick start
 
 1. Install the [.NET 9 SDK preview](https://dotnet.microsoft.com/download/dotnet/9.0).
-2. Export your OpenAI API key:
+2. Install [ripgrep](https://github.com/BurntSushi/ripgrep) and ensure `rg` is in your `PATH` (the runtime Docker image already includes it).
+3. Export your OpenAI API key:
 
    ```powershell
    $env:SHELLMUSE_OPENAIAPIKEY = "sk-..."
    ```
 
-3. Build the solution (this runs the CSharpier formatter automatically):
+4. Build the solution (this runs the CSharpier formatter automatically):
 
    ```bash
    dotnet build
    ```
 
-4. Ask a question:
+5. Ask a question:
 
    ```bash
    dotnet run --project src/ShellMuse.Cli -- ask "2+2"
    ```
 
-5. Run a task inside the sandbox (Docker required, pulls `mcr.microsoft.com/dotnet/nightly/sdk:9.0` by default):
+6. Run a task inside the sandbox (Docker required, pulls `mcr.microsoft.com/dotnet/nightly/sdk:9.0` by default):
 
    ```bash
    dotnet run --project src/ShellMuse.Cli -- run "build the project"

--- a/src/ShellMuse.Core/Planning/Tools/SearchTool.cs
+++ b/src/ShellMuse.Core/Planning/Tools/SearchTool.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.IO;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -7,17 +8,28 @@ namespace ShellMuse.Core.Planning.Tools;
 
 public class SearchTool : ITool
 {
+    private static string ResolveRgCommand()
+    {
+        var custom = Environment.GetEnvironmentVariable("SHELLMUSE_RIPGREP");
+        return string.IsNullOrWhiteSpace(custom) ? "rg" : custom;
+    }
+
     public async Task<string> RunAsync(JsonElement args, CancellationToken cancellationToken = default)
     {
         var query = args.GetProperty("query").GetString() ?? string.Empty;
         var path = args.TryGetProperty("path", out var p) ? p.GetString() ?? "." : ".";
+        var command = ResolveRgCommand();
         try
         {
-            return await ProcessUtil.RunAsync("rg", $"{query} {path}", cancellationToken);
+            return await ProcessUtil.RunAsync(command, $"{query} {path}", cancellationToken);
+        }
+        catch (Win32Exception) when (!File.Exists(command))
+        {
+            return $"ripgrep not found (tried '{command}'). Install ripgrep or set SHELLMUSE_RIPGREP.";
         }
         catch (Win32Exception)
         {
-            return "ripgrep (rg) not found. Please install ripgrep to enable the search tool.";
+            return "ripgrep (rg) failed to start.";
         }
     }
 }

--- a/src/ShellMuse.Core/Planning/Tools/SearchTool.cs
+++ b/src/ShellMuse.Core/Planning/Tools/SearchTool.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -6,10 +7,17 @@ namespace ShellMuse.Core.Planning.Tools;
 
 public class SearchTool : ITool
 {
-    public Task<string> RunAsync(JsonElement args, CancellationToken cancellationToken = default)
+    public async Task<string> RunAsync(JsonElement args, CancellationToken cancellationToken = default)
     {
         var query = args.GetProperty("query").GetString() ?? string.Empty;
         var path = args.TryGetProperty("path", out var p) ? p.GetString() ?? "." : ".";
-        return ProcessUtil.RunAsync("rg", $"{query} {path}", cancellationToken);
+        try
+        {
+            return await ProcessUtil.RunAsync("rg", $"{query} {path}", cancellationToken);
+        }
+        catch (Win32Exception)
+        {
+            return "ripgrep (rg) not found. Please install ripgrep to enable the search tool.";
+        }
     }
 }

--- a/tests/ShellMuse.Tests/SearchToolTests.cs
+++ b/tests/ShellMuse.Tests/SearchToolTests.cs
@@ -11,10 +11,12 @@ public class SearchToolTests
     [Fact]
     public async Task ReturnsMessageWhenRipgrepMissing()
     {
-        var original = Environment.GetEnvironmentVariable("PATH");
+        var originalPath = Environment.GetEnvironmentVariable("PATH");
+        var originalCustom = Environment.GetEnvironmentVariable("SHELLMUSE_RIPGREP");
         try
         {
             Environment.SetEnvironmentVariable("PATH", string.Empty);
+            Environment.SetEnvironmentVariable("SHELLMUSE_RIPGREP", null);
             var tool = new SearchTool();
             var args = JsonDocument.Parse("{\"query\":\"foo\"}").RootElement;
             var result = await tool.RunAsync(args);
@@ -22,7 +24,26 @@ public class SearchToolTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("PATH", original);
+            Environment.SetEnvironmentVariable("PATH", originalPath);
+            Environment.SetEnvironmentVariable("SHELLMUSE_RIPGREP", originalCustom);
+        }
+    }
+
+    [Fact]
+    public async Task UsesCustomRipgrepPath()
+    {
+        var original = Environment.GetEnvironmentVariable("SHELLMUSE_RIPGREP");
+        try
+        {
+            Environment.SetEnvironmentVariable("SHELLMUSE_RIPGREP", "echo");
+            var tool = new SearchTool();
+            var args = JsonDocument.Parse("{\"query\":\"foo\"}").RootElement;
+            var result = await tool.RunAsync(args);
+            Assert.Contains("foo", result);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("SHELLMUSE_RIPGREP", original);
         }
     }
 }

--- a/tests/ShellMuse.Tests/SearchToolTests.cs
+++ b/tests/ShellMuse.Tests/SearchToolTests.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using ShellMuse.Core.Planning.Tools;
+using Xunit;
+
+namespace ShellMuse.Tests;
+
+public class SearchToolTests
+{
+    [Fact]
+    public async Task ReturnsMessageWhenRipgrepMissing()
+    {
+        var original = Environment.GetEnvironmentVariable("PATH");
+        try
+        {
+            Environment.SetEnvironmentVariable("PATH", string.Empty);
+            var tool = new SearchTool();
+            var args = JsonDocument.Parse("{\"query\":\"foo\"}").RootElement;
+            var result = await tool.RunAsync(args);
+            Assert.Contains("ripgrep", result, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PATH", original);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- catch `Win32Exception` when `rg` is missing
- add test verifying the fallback message

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684750bcc2388331865de735a65b9a13