### PR TITLE
Handle code fences when parsing tool output

### DIFF
--- a/src/ShellMuse.Core/Planning/ToolCall.cs
+++ b/src/ShellMuse.Core/Planning/ToolCall.cs
@@ -13,6 +13,7 @@ public record ToolCall(Tool Tool, JsonElement Args)
         error = null;
         try
         {
+            json = CleanJson(json);
             using var doc = JsonDocument.Parse(json);
             var root = doc.RootElement;
             if (!root.TryGetProperty("tool", out var toolProp))
@@ -38,5 +39,20 @@ public record ToolCall(Tool Tool, JsonElement Args)
             error = je.Message;
             return false;
         }
+    }
+
+    private static string CleanJson(string text)
+    {
+        var trimmed = text.Trim();
+        if (trimmed.StartsWith("```"))
+        {
+            var newline = trimmed.IndexOf('\n');
+            if (newline != -1)
+                trimmed = trimmed[(newline + 1)..];
+            if (trimmed.EndsWith("```"))
+                trimmed = trimmed[..^3];
+        }
+
+        return trimmed.Trim();
     }
 }


### PR DESCRIPTION
## Summary
- make `ToolCall.TryParse` strip code fences from LLM output

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684756fe4b448331b84054ad65033ba1