### PR TITLE
Fix system prompt for strict tool JSON

### DIFF
--- a/src/ShellMuse.Core/Providers/OpenAIChatProvider.cs
+++ b/src/ShellMuse.Core/Providers/OpenAIChatProvider.cs
@@ -42,7 +42,8 @@ public class OpenAIChatProvider : IChatProvider
                 new
                 {
                     role = "system",
-                    content = "You are a coding agent. Respond ONLY with JSON matching {\"tool\":string, \"args\":object}. Available tools: search, read_file, write_file, build, test, commit, branch, finish.",
+                    content =
+                        "You are a coding agent. Respond ONLY with a JSON object containing a 'tool' property and an 'args' object. Example: {\"tool\":\"search\",\"args\":{\"query\":\"foo\"}}. Available tools: search, read_file, write_file, build, test, commit, branch, finish.",
                 },
                 new { role = "user", content = prompt },
             },

--- a/tests/ShellMuse.Tests/ToolCallTests.cs
+++ b/tests/ShellMuse.Tests/ToolCallTests.cs
@@ -35,4 +35,14 @@ public class ToolCallTests
         Assert.Null(call);
         Assert.False(string.IsNullOrEmpty(error));
     }
+
+    [Fact]
+    public void ToolNameAsPropertyFails()
+    {
+        var json = "{\"branch\":\"feature\"}";
+        var ok = ToolCall.TryParse(json, out var call, out var error);
+        Assert.False(ok);
+        Assert.Null(call);
+        Assert.Equal("Missing 'tool' property", error);
+    }
 }


### PR DESCRIPTION
## Summary
- revert overly permissive tool-call parsing
- clarify system prompt with example JSON shape
- test that alt tool call syntax is rejected

## Testing
- `dotnet test ShellMuse.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68475852c3008331ba72e15052fd19e0